### PR TITLE
Add aarch64 to known architectures.

### DIFF
--- a/src/utk_platform_macros.hpp
+++ b/src/utk_platform_macros.hpp
@@ -134,6 +134,8 @@
     #define UTK__Arch_ARM_ARM
   #elif defined(__arm__) && defined(__thumb__)
     #define UTK__Arch_ARM_THUMB
+  #elif defined(__aarch64__)
+    #define UTK__Aarch_AARCH64
   #elif defined(__sh__)
     #define UTK__Arch_SuperH
   #else


### PR DESCRIPTION
Set an appropriate label when encountering a system running on aarch64. This label (like the other architecture labels) is not used.