### PR TITLE
memory.limit() is no longer supported

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,7 +6,7 @@
 
 useDynLib(ff, .registration = TRUE, .fixes = "C_")
 
-importFrom(utils, memory.limit, packageDescription, read.fwf, read.table, str, write.table)
+importFrom(utils, packageDescription, read.fwf, read.table, str, write.table)
 importFrom(stats, median, quantile, runif)
 import(bit)
 

--- a/R/ff.R
+++ b/R/ff.R
@@ -2115,7 +2115,7 @@ str.ff <- function(object, nest.lev=0, ...){
 #!   \code{ffpagesize}    \tab default pagesize                             \tab \code{\link{getdefaultpagesize}} \cr
 #!   \code{ffcaching}     \tab caching scheme for the C++ backend           \tab \code{'mmnoflush'} \cr
 #!   \code{ffdrop}        \tab default for the \option{drop} parameter in the ff subscript methods  \tab TRUE \cr
-#!   \code{ffbatchbytes}  \tab default for the byte limit in batched/chunked processing             \tab \code{\link{memory.limit}() \%/\% 100} \cr
+#!   \code{ffbatchbytes}  \tab default for the byte limit in batched/chunked processing             \tab 16MB \cr
 #!  }
 #! }
 #! \section{OS specific}{

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -48,30 +48,12 @@
   if (is.null(getOption("ffdrop")))
     options(ffdrop=TRUE)
   if (is.null(getOption("ffbatchbytes"))){
-    # memory.limit is windows specific
-    if (.Platform$OS.type=="windows")
-    {
-      if (getRversion()>="2.6.0")  # memory.limit was silently changed from 2.6.0 to return in MB instead of bytes
-        options(ffbatchbytes=memory.limit()*(1024^2/100))
-      else
-        options(ffbatchbytes=memory.limit()/100)
-    } else {
-      # some magic constant
-      options(ffbatchbytes=16*1024^2)
-    }
+    # some magic constant
+    options(ffbatchbytes=16*1024^2)
   }
   if (is.null(getOption("ffmaxbytes"))){
-    # memory.limit is windows specific
-    if (.Platform$OS.type=="windows")
-    {
-      if (getRversion()>="2.6.0")  # memory.limit was silently changed from 2.6.0 to return in MB instead of bytes
-        options(ffmaxbytes=0.5*memory.limit()*(1024^2))
-      else
-        options(ffmaxbytes=0.5*memory.limit())
-    } else {
-      # some magic constant
-      options(ffmaxbytes=0.5*1024^3)
-    }
+    # some magic constant
+    options(ffmaxbytes=0.5*1024^3)
   }
   # if we want an explicit list of ff objects, we should store them in an environment with hash=TRUE (much faster than a list)
   #assign(".fftemp", new.env(hash=TRUE), envir=globalenv())

--- a/man/ff.rd
+++ b/man/ff.rd
@@ -229,7 +229,7 @@ ff( initdata  = NULL
   \code{ffpagesize}    \tab default pagesize                             \tab \code{\link{getdefaultpagesize}} \cr
   \code{ffcaching}     \tab caching scheme for the C++ backend           \tab \code{'mmnoflush'} \cr
   \code{ffdrop}        \tab default for the \option{drop} parameter in the ff subscript methods  \tab TRUE \cr
-  \code{ffbatchbytes}  \tab default for the byte limit in batched/chunked processing             \tab \code{\link{memory.limit}() \%/\% 100} \cr
+  \code{ffbatchbytes}  \tab default for the byte limit in batched/chunked processing             \tab 16MB \cr
  }
 }
 \section{OS specific}{


### PR DESCRIPTION
Hi Jens,

R-devel recently dropped support for `memory.limit()`: https://developer.r-project.org/blosxom.cgi/R-devel/NEWS/2021/08/31 It is a stub now that generates a warning and returns `Inf`, like in the Unix version of the function. The warning causes packages that depend on `ff` and use it in tests or examples to not pass `R CMD check`.

Cheers,
Alex