### PR TITLE
fix for https://github.com/truecluster/ff/issues/11

### DIFF
--- a/R/ff.R
+++ b/R/ff.R
@@ -3655,7 +3655,7 @@ getset.ff <- function(x, i, value, add=FALSE)
   if( is.readonly(x) ) stop("ff is readonly")
   if (is.double(i))
     i <- as.integer(i)
-  if (!is.integer(i) || i<1 || i>length(x)) stop("illegal index")
+  if (!is.integer(i) || any(i<1) || any(i>length(x))) stop("illegal index")
   if(!is.null(vw(x))) stop("please use '[' to access ff with vw")
 
   nc <- na.count(x)


### PR DESCRIPTION
Calling && or || with either argument of length greater than one now gives a warning (which it is intended will become an error) 
ffbase fails because of this https://www.stats.ox.ac.uk/pub/bdr/LENGTH1/ffbase.out and was removed from CRAN


```
library(ff)
x <- ff(1:5)
ff:::getset.ff(x, i = as.numeric(c(2, 3)), value = c(0, 0))
x
```